### PR TITLE
updated to comply with pep8 and bandit, also added tmp file cleanup

### DIFF
--- a/src/conversion/conversion.py
+++ b/src/conversion/conversion.py
@@ -123,10 +123,17 @@ def handler(event, context):
 
         finally:
             filesToRemove = os.listdir(tmpdir)
+
             for f in filesToRemove:
                 file_path = os.path.join(tmpdir, f)
                 print(f'Removing File: {file_path}')
-                os.remove(file_path)
+
+                try:
+                    os.remove(file_path)
+                except OSError as e:
+                    print(e)
+                    print(f'Error while deleting file {file_path}')
+
             print(f'Removing Folder: {tmpdir}')
             os.rmdir(tmpdir)
 


### PR DESCRIPTION
I have updated the code to comply with pep8 and bandit linting. Removed excess whitespace and added basic handling around the temporary files as we should clean up really. 

I am using the tempfile module to create a separate tmp directory as it makes it easy to remove it and still allows for use of /tmp if there is a reason to take advantage of the same container whilst not maintaining files converted on the last execution.   Needs error handling still, and I am not sure if it should be moved outside the try / catch and do a single cleanup at the end rather than for each file.